### PR TITLE
Show cafes on home page (and setup DB helpers for specs)

### DIFF
--- a/app/repo.rb
+++ b/app/repo.rb
@@ -1,0 +1,11 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "rom-repository"
+
+module Decafsucks
+  class Repo < ROM::Repository::Root
+    # TODO(Hanami): this line will not be needed once Hanami's persistence layer is released
+    include Deps[container: "persistence.rom"]
+  end
+end

--- a/config/app.rb
+++ b/config/app.rb
@@ -5,5 +5,8 @@ require "ext/hanami/providers/rack"
 
 module Decafsucks
   class App < Hanami::App
+    config.inflections do |i|
+      i.plural "cafe", "cafes"
+    end
   end
 end

--- a/config/providers/persistence.rb
+++ b/config/providers/persistence.rb
@@ -6,6 +6,9 @@ Hanami.app.register_provider :persistence, namespace: true do
     require "rom/core"
     require "rom/sql"
 
+    # TODO(Hanami): As part of built-in rom setup, configure ROM with app inflector
+    silence_warnings { ROM::Inflector = Hanami.app["inflector"] }
+
     rom_config = ROM::Configuration.new(:sql, target["settings"].database_url)
 
     rom_config.plugin(:sql, relations: :instrumentation) do |plugin_config|
@@ -26,5 +29,13 @@ Hanami.app.register_provider :persistence, namespace: true do
     )
 
     register "rom", ROM.container(rom_config)
+  end
+
+  define_method(:silence_warnings) do |&block|
+    orig_verbose = $VERBOSE
+    $VERBOSE = nil
+    result = block.call
+    $VERBOSE = orig_verbose
+    result
   end
 end

--- a/slices/main/repo.rb
+++ b/slices/main/repo.rb
@@ -1,0 +1,7 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module Main
+  class Repo < Decafsucks::Repo
+  end
+end

--- a/slices/main/repos/cafe_repo.rb
+++ b/slices/main/repos/cafe_repo.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Main
+  module Repos
+    class CafeRepo < Main::Repo[:cafes]
+      def latest
+        cafes.order { created_at.desc }.to_a
+      end
+    end
+  end
+end

--- a/slices/main/templates/home/show.html.slim
+++ b/slices/main/templates/home/show.html.slim
@@ -1,1 +1,7 @@
 h1 Decaf Sucks
+
+h2 Cafes
+
+- cafes.each do |cafe|
+  div
+    p = cafe.name

--- a/slices/main/views/home/show.rb
+++ b/slices/main/views/home/show.rb
@@ -4,6 +4,11 @@ module Main
   module Views
     module Home
       class Show < Main::View
+        include Deps["repos.cafe_repo"]
+
+        expose :cafes do
+          cafe_repo.latest
+        end
       end
     end
   end

--- a/spec/factories/cafe.rb
+++ b/spec/factories/cafe.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Test::Factory.define(:cafe) do |f|
+  f.name { "#{fake(:coffee, :blend_name)} Cafe" }
+  f.name_dmetaphone { |name| "cafe" } # TODO: add real double metaphone support
+  f.address { fake(:address, :full_address) }
+  f.lat { fake(:address, :latitude) }
+  f.lng { fake(:address, :longitude) }
+  f.rating { 1.upto(10).to_a.sample }
+  f.created_at { Time.now }
+end

--- a/spec/slices/main/features/home_page_spec.rb
+++ b/spec/slices/main/features/home_page_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe "Home page", :web do
+RSpec.describe "Home page", :web, :db do
   specify "Visiting the home page" do
+    factory[:cafe, name: "Group Seven"]
+    factory[:cafe, name: "Harvest"]
+
     visit "/"
+
+    expect(page).to have_content("Group Seven")
+    expect(page).to have_content("Harvest")
   end
 end

--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -1,0 +1,26 @@
+# require_with_metadata: true
+# frozen_string_literal: true
+
+require_relative "db/helpers"
+require_relative "db/database_cleaner"
+require_relative "db/factory"
+
+RSpec.configure do |config|
+  config.before :suite do
+    Hanami.app.start :persistence
+  end
+
+  config.include Test::DB::Helpers, :db
+
+  # Configure per-slice factory helpers
+  Dir[SPEC_ROOT.join("slices", "*")].each do |slice_dir|
+    slice_name = File.basename(slice_dir).to_sym
+
+    config.define_derived_metadata(db: true, file_path: Regexp.escape(slice_dir)) do |metadata|
+      metadata[:factory] = slice_name
+    end
+
+    config.include(Test::DB::FactoryHelper.new(slice_name), factory: slice_name)
+  end
+  config.include(Test::DB::FactoryHelper.new, factory: nil)
+end

--- a/spec/support/db/database_cleaner.rb
+++ b/spec/support/db/database_cleaner.rb
@@ -1,0 +1,21 @@
+require "database_cleaner/sequel"
+require_relative "helpers"
+
+DatabaseCleaner[:sequel].strategy = :transaction
+
+RSpec.configure do |config|
+  config.before :suite do
+    DatabaseCleaner[:sequel].clean_with :truncation
+  end
+
+  config.prepend_before :each, :db do |example|
+    strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner[:sequel].strategy = strategy
+
+    DatabaseCleaner[:sequel].start
+  end
+
+  config.append_after :each, :db do
+    DatabaseCleaner[:sequel].clean
+  end
+end

--- a/spec/support/db/factory.rb
+++ b/spec/support/db/factory.rb
@@ -1,0 +1,59 @@
+require "rom-factory"
+require_relative "helpers"
+
+module Test
+  Factory = ROM::Factory.configure { |config|
+    config.rom = Test::DB::Helpers.rom
+  }
+
+  module DB
+    class FactoryHelper < Module
+      ENTITIES_MODULE_NAME = :Entities
+
+      attr_reader :slice_name
+
+      def initialize(slice_name = nil)
+        @slice_name = slice_name
+
+        factory = entity_namespace ? Test::Factory.struct_namespace(entity_namespace) : Factory
+
+        define_method(:factory) do
+          factory
+        end
+      end
+
+      private
+
+      def entity_namespace
+        return @entity_namespace if instance_variable_defined?(:@entity_namespace)
+
+        slice = slice_name ? Hanami.app.slices[slice_name] : Hanami.app
+        slice_namespace = slice.namespace
+
+        @entity_namespace =
+          if slice_namespace.const_defined?(ENTITIES_MODULE_NAME)
+            slice_namespace.const_get(ENTITIES_MODULE_NAME)
+          end
+      end
+    end
+  end
+end
+
+# Patch rom-factory to use our app inflector
+#
+# TODO(rom-factory): Support a configurable inflector
+class ROM::Factory::Factories
+  module Fixes
+    def infer_factory_name(name)
+      Hanami.app["inflector"].singularize(name).to_sym
+    end
+
+    def infer_relation(name)
+      Hanami.app["inflector"].pluralize(name).to_sym
+    end
+  end
+
+  prepend Fixes
+end
+
+Dir[SPEC_ROOT.join("factories/**/*.rb")].each { require(_1) }

--- a/spec/support/db/helpers.rb
+++ b/spec/support/db/helpers.rb
@@ -1,0 +1,19 @@
+module Test
+  module DB
+    module Helpers
+      module_function
+
+      def relations
+        rom.relations
+      end
+
+      def rom
+        Hanami.app["persistence.rom"]
+      end
+
+      def db
+        Hanami.app["persistence.db"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Welcome to our first app feature interacting with the database! 🎉 

This means we need to do a few things to set up. For starters, I've imported my preferred DB setup for RSpec. This leverages a bunch of RSpec configuration power to make it so that we can just add the `:db` metadata to any RSpec example or example group, and we automatically have database cleaning and a test `factory` helper set up for us.

Along with this, we have to do a few little hacks to inform rom and rom-factory about our `Hanami.app["inflector"]`, because we have a custom pluralization to make sure "cafe" isn't pluralized to "caves".

With this setup out of the way, now we can define a simple cafe factory, set up a basic `Main::Repos::CafeRepo` that we use from within our `Main::Views::Home::Show` to expose a list of cafes to the template, which we then render.

The resulting test is pretty straightforward to read:

```ruby
# frozen_string_literal: true

RSpec.describe "Home page", :web, :db do
  specify "Visiting the home page" do
    factory[:cafe, name: "Group Seven"]
    factory[:cafe, name: "Harvest"]

    visit "/"

    expect(page).to have_content("Group Seven")
    expect(page).to have_content("Harvest")
  end
end
```

And it passes! 💚

The commits in this PR are granular so you should be able to see things piece by piece if that helps.

Now that we've got over the hump with this initial database setup, we should be able to iterate much more simply on future DB-backed features.