### PR TITLE
Add Rubocop

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,11 @@
 steps:
+  - label: Lint
+    commands:
+      - gem install standard
+      - rubocop
+    plugins:
+      docker#v5.3.0:
+        image: "ruby:3.1"
   - label: Run tests
     commands:
       - HANAMI_ENV=test bin/hanami db create

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+# Thanks to https://evilmartians.com/chronicles/rubocoping-with-legacy-bring-your-ruby-code-up-to-standard
+
+inherit_mode:
+  merge:
+    - Exclude
+
+require:
+  - rubocop-performance
+  - standard
+
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  SuggestExtensions: false
+
+Style/GlobalVars:
+  Exclude:
+    - bin/setup

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 group :development, :test do
   # .env file support
   gem "dotenv"
+  gem "standard"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
     capybara (3.38.0)
       addressable
       matrix
@@ -122,6 +123,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    json (2.6.2)
     matrix (0.4.2)
     mini_mime (1.1.2)
     mustermann (1.1.2)
@@ -132,6 +134,9 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
+    parallel (1.22.1)
+    parser (3.1.3.0)
+      ast (~> 2.4.1)
     pg (1.4.5)
     public_suffix (5.0.0)
     puma (6.0.0)
@@ -140,8 +145,10 @@ GEM
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
+    rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.1)
+    rexml (3.2.5)
     rom (5.3.0)
       rom-changeset (~> 5.3, >= 5.3.0)
       rom-core (~> 5.3, >= 5.3.0)
@@ -187,14 +194,34 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    rubocop (1.39.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.23.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.15.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     sequel (5.62.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
+    standard (1.18.1)
+      rubocop (= 1.39.0)
+      rubocop-performance (= 1.15.1)
     temple (0.8.2)
     tilt (2.0.11)
     transproc (1.1.1)
+    unicode-display_width (2.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)
@@ -222,6 +249,7 @@ DEPENDENCIES
   rom-sql
   sequel
   slim
+  standard
 
 BUNDLED WITH
    2.3.25

--- a/bin/setup
+++ b/bin/setup
@@ -67,7 +67,7 @@ end
 # explicitly puts what we are executing, so we use this method instead of Kernel#system and friends
 def system!(*args)
   unless system(*args)
-    msg = args.length == 1 ? args.first.inspect : args.inspect
+    msg = (args.length == 1) ? args.first.inspect : args.inspect
     puts "\n\e[1mCommand failed:\e[0m #{msg}"
 
     exit $?.exitstatus

--- a/db/sample_data.rb
+++ b/db/sample_data.rb
@@ -11,5 +11,5 @@ cafes.insert(
   lng: 149.13362100,
   rating: 9,
   reviews_count: 1,
-  created_at: Time.now,
+  created_at: Time.now
 )


### PR DESCRIPTION
Add the standard gem and use its rules for running `rubocop` directly (I prefer this approach because it means we get the benefit of Standard's rules while still supporting any other Rubocop-specific extensions or integrations).

Add a new "Lint" step to our Buildkite pipeline to run `rubocop`. To keep things simple right now, this is just installing the standard gem on top of a vanilla Ruby docker image. Later I might consider adding a "build" step as a precursor to anything that requires our app's Ruby environment.