### PR TITLE
Call #disconnect on "persistence.rom" at persistence-providers stop-lifecycle-block

### DIFF
--- a/config/providers/persistence.rb
+++ b/config/providers/persistence.rb
@@ -31,6 +31,10 @@ Hanami.app.register_provider :persistence, namespace: true do
     register "rom", ROM.container(rom_config)
   end
 
+  stop do 
+    target["persistence.rom"].disconnect
+  end
+
   define_method(:silence_warnings) do |&block|
     orig_verbose = $VERBOSE
     $VERBOSE = nil


### PR DESCRIPTION
Hey,
if this hanami-app is started with multiple threads, the persistence-teardown is missing before forking. Therefore, strange bugs (race conditions, etc...) can appear here.
I think calling `target["persistence.rom"].disconnect` fixes the issue. WDYT?

best regards