### PR TITLE
Ensure that the account_statuses table does not get truncated

### DIFF
--- a/spec/support/db/cleaning.rb
+++ b/spec/support/db/cleaning.rb
@@ -5,8 +5,7 @@ require "database_cleaner/sequel"
 # Clean the databases between tests tagged as `:db`
 RSpec.configure do |config|
   skip_cleaning_tables = [
-    "account_statuses",
-    "schema_migrations"
+    "account_statuses"
   ]
 
   # Returns all the configured databases across the app and its slices.
@@ -34,7 +33,7 @@ RSpec.configure do |config|
     strategy = example.metadata[:js] ? :truncation : :transaction
 
     all_databases.call.each do |db|
-      DatabaseCleaner[:sequel, db: db].strategy = strategy
+      DatabaseCleaner[:sequel, db: db].strategy = strategy, { except: skip_cleaning_tables }
       DatabaseCleaner[:sequel, db: db].start
     end
   end


### PR DESCRIPTION
When I implemented this solution in my app, the account_statuses table kept getting truncated.

The problem was that the code in the `around :each` callback used the truncation strategy without setting the `except` tables. Since `schema_migrations` is already excluded inside the `database_cleaner-sequel` gem, this probably masked the fact that the `around :each` block truncates _everything else_.

With this proposed change the database cleaning should work as expected.