### PR TITLE
Run postgres tools inside container via binstubs

### DIFF
--- a/bin/createdb
+++ b/bin/createdb
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+
+# Delegates to createdb inside the postgres Docker container.
+#
+# Expects the "postgres" service from docker-compose.yml to be running.
+
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
+TTY_FLAG="--no-tty"
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_FLAG=""
+fi
+
+exec docker compose exec $TTY_FLAG \
+  -e PGUSER="$DECAFSUCKS_POSTGRES_CLI_USER" \
+  -e PGPASSWORD="$DECAFSUCKS_POSTGRES_CLI_PASSWORD" \
+  postgres createdb "$@"

--- a/bin/dropdb
+++ b/bin/dropdb
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+
+# Delegates to dropdb inside the postgres Docker container.
+#
+# Expects the "postgres" service from docker-compose.yml to be running.
+
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
+TTY_FLAG="--no-tty"
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_FLAG=""
+fi
+
+exec docker compose exec $TTY_FLAG \
+  -e PGUSER="$DECAFSUCKS_POSTGRES_CLI_USER" \
+  -e PGPASSWORD="$DECAFSUCKS_POSTGRES_CLI_PASSWORD" \
+  postgres dropdb "$@"

--- a/bin/pg_dump
+++ b/bin/pg_dump
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+
+# Delegates to pg_dump inside the postgres Docker container.
+#
+# Expects the "postgres" service from docker-compose.yml to be running.
+
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
+TTY_FLAG="--no-tty"
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_FLAG=""
+fi
+
+exec docker compose exec $TTY_FLAG \
+  -e PGUSER="$DECAFSUCKS_POSTGRES_CLI_USER" \
+  -e PGPASSWORD="$DECAFSUCKS_POSTGRES_CLI_PASSWORD" \
+  postgres pg_dump "$@"

--- a/bin/pg_restore
+++ b/bin/pg_restore
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+
+# Delegates to pg_restore inside the postgres Docker container.
+#
+# Expects the "postgres" service from docker-compose.yml to be running.
+
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
+TTY_FLAG="--no-tty"
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_FLAG=""
+fi
+
+exec docker compose exec $TTY_FLAG \
+  -e PGUSER="$DECAFSUCKS_POSTGRES_CLI_USER" \
+  -e PGPASSWORD="$DECAFSUCKS_POSTGRES_CLI_PASSWORD" \
+  postgres pg_restore "$@"

--- a/bin/psql
+++ b/bin/psql
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+
+# Delegates to psql inside the postgres Docker container.
+#
+# Expects the "postgres" service from docker-compose.yml to be running.
+
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
+TTY_FLAG="--no-tty"
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_FLAG=""
+fi
+
+exec docker compose exec $TTY_FLAG \
+  -e PGUSER="$DECAFSUCKS_POSTGRES_CLI_USER" \
+  -e PGPASSWORD="$DECAFSUCKS_POSTGRES_CLI_PASSWORD" \
+  postgres psql "$@"

--- a/config/db/structure.sql
+++ b/config/db/structure.sql
@@ -3,6 +3,7 @@
 --
 
 
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -368,6 +369,8 @@ ALTER TABLE ONLY public.reviews
 --
 -- PostgreSQL database dump complete
 --
+
+
 SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (filename) VALUES

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,13 @@
+[settings]
+# Add to the very beginning of $PATH, ensuring our binstubs take precedence
+activate_aggressive = true
+
+[env]
+_.path = ["bin"]
+# Used from our Postgres binstubs, matching the values set in docker-compose.yml
+DECAFSUCKS_POSTGRES_CLI_USER = "postgres"
+DECAFSUCKS_POSTGRES_CLI_PASSWORD = "postgres"
+
 [tools]
 node = "22.16.0"
 ruby = "3.4.4"


### PR DESCRIPTION
- Have Mise add `bin/` to the beginning of `$PATH`
- Have Mise set `DECAFSUCKS_POSTGRES_CLI_USER` and `_PASSWORD` to env, with the values that will work for our database in the `postgres` container
- Add binstubs for all the Postgres CLI tools to bin/, which are shell scripts that run the respective tools inside our `postgres` container, using the env vars to set username and password

I've tested this with all the `hanami db` commands and they seem to work smoothly. Plain interactive `psql` also works well:

```
❯ which psql
/Users/timriley/Source/decafsucks/decafsucks/bin/psql

❯ psql --version
psql (PostgreSQL) 17.6

❯ psql decafsucks_development
psql (17.6)
Type "help" for help.

decafsucks_development=# \d
                     List of relations
 Schema |            Name             |   Type   |  Owner
--------+-----------------------------+----------+----------
 public | account_login_change_keys   | table    | postgres
 public | account_password_reset_keys | table    | postgres
 public | account_remember_keys       | table    | postgres
 public | account_statuses            | table    | postgres
 public | account_verification_keys   | table    | postgres
 public | accounts                    | table    | postgres
 public | accounts_id_seq             | sequence | postgres
 public | cafes                       | table    | postgres
 public | cafes_id_seq                | sequence | postgres
 public | reviews                     | table    | postgres
 public | reviews_id_seq              | sequence | postgres
 public | schema_migrations           | table    | postgres
 public | users                       | table    | postgres
 public | users_id_seq                | sequence | postgres
(14 rows)
```

With this change, we no longer require Postgres CLI tools to be installed on the host machine, and will also avoid any issues from version mismatches between the tools on the host and Postgres in the container.