### PR TITLE
Add flow for writing cafe reviews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://gem.coop"
 
-# App framework
+# Hanami
 gem "hanami", github: "hanami/hanami", branch: "main"
 gem "hanami-cli", github: "hanami/cli", branch: "main"
 gem "hanami-utils", github: "hanami/utils", branch: "main"
@@ -12,21 +12,28 @@ gem "hanami-db", github: "hanami/db", branch: "main"
 gem "hanami-router", github: "hanami/router", branch: "main"
 gem "hanami-view", github: "hanami/view", branch: "main"
 
-# Framework support
-gem "dry-types"
-gem "puma"
-gem "rake"
-
 # Database
 gem "pg"
 
+# Framework support
+gem "puma"
+gem "rake"
+
 # Core tools
+gem "dry-operation"
 gem "dry-struct"
-gem "faraday"
+gem "dry-types"
+gem "dry-validation"
+
+# Text algorithms (for cafe name matching)
+gem "text"
 
 # Authentication
 gem "rodauth"
 gem "bcrypt"
+
+# HTTP
+gem "faraday"
 
 # Mail
 gem "mail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,10 +189,25 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
+    dry-monads (1.9.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
     dry-monitor (1.0.1)
       dry-configurable (~> 1.0, < 2)
       dry-core (~> 1.0, < 2)
       dry-events (~> 1.0, < 2)
+    dry-operation (1.1.0)
+      dry-monads (~> 1.6)
+      zeitwerk (~> 2.6)
+    dry-schema (1.16.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.6)
+      dry-types (~> 1.9, >= 1.9.1)
+      zeitwerk (~> 2.6)
     dry-struct (1.8.1)
       dry-core (~> 1.1)
       dry-types (~> 1.8, >= 1.8.2)
@@ -212,6 +227,12 @@ GEM
       dry-core (~> 1.0)
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    dry-validation (1.11.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-schema (~> 1.14)
       zeitwerk (~> 2.6)
     erb (6.0.2)
     erubi (1.13.1)
@@ -428,6 +449,7 @@ GEM
       rubocop-performance (~> 1.26.0)
     stringio (3.2.0)
     temple (0.10.4)
+    text (1.3.1)
     thor (1.5.0)
     tilt (2.7.0)
     timeout (0.6.1)
@@ -453,8 +475,10 @@ DEPENDENCIES
   capybara
   database_cleaner-sequel
   dotenv
+  dry-operation
   dry-struct
   dry-types
+  dry-validation
   faraday
   hanami!
   hanami-assets!
@@ -476,6 +500,7 @@ DEPENDENCIES
   rodauth
   rom-factory
   standard
+  text
   vcr
 
 BUNDLED WITH

--- a/app/action.rb
+++ b/app/action.rb
@@ -5,5 +5,6 @@ require "hanami/action"
 
 module Decafsucks
   class Action < Hanami::Action
+    include Dry::Monads[:result]
   end
 end

--- a/app/operation.rb
+++ b/app/operation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "dry/operation"
+
+module Decafsucks
+  class Operation < Dry::Operation
+  end
+end

--- a/config/db/migrate/20221123201330_create_cafes.rb
+++ b/config/db/migrate/20221123201330_create_cafes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ROM::SQL.migration do
-  change do
+  up do
     create_table :cafes do
       primary_key :id
       column :name, :text, null: false
@@ -15,5 +15,14 @@ ROM::SQL.migration do
       column :last_reviewed_at, :timestamp
       column :closed_at, :timestamp
     end
+
+    run <<~SQL
+      CREATE UNIQUE INDEX cafes_name_dmetaphone_lat_lng_unique
+      ON cafes (name_dmetaphone, round(lat, 4), round(lng, 4))
+    SQL
+  end
+
+  down do
+    drop_table :cafes
   end
 end

--- a/config/db/structure.sql
+++ b/config/db/structure.sql
@@ -311,6 +311,13 @@ CREATE UNIQUE INDEX accounts_email_index ON public.accounts USING btree (email) 
 
 
 --
+-- Name: cafes_name_dmetaphone_lat_lng_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX cafes_name_dmetaphone_lat_lng_unique ON public.cafes USING btree (name_dmetaphone, round(lat, 4), round(lng, 4));
+
+
+--
 -- Name: account_login_change_keys account_login_change_keys_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ module Decafsucks
       root to: "home.show"
 
       resources :cafes, only: %i[show]
-      resources :reviews, only: %i[new]
+      resources :reviews, only: %i[new create]
       resource :account, only: %i[show]
     end
   end

--- a/slices/geocoding/result.rb
+++ b/slices/geocoding/result.rb
@@ -7,7 +7,7 @@ module Geocoding
   # A place result from a geocoding service.
   class Result < Dry::Struct
     attribute :display_name, Types::String
-    attribute :lat, Types::String
-    attribute :lng, Types::String
+    attribute :lat, Types::Coercible::Decimal
+    attribute :lng, Types::Coercible::Decimal
   end
 end

--- a/slices/main/actions/account/show.rb
+++ b/slices/main/actions/account/show.rb
@@ -7,7 +7,7 @@ module Main
         def handle(request, response)
           response.render(
             view,
-            account_id: response[:current_account_id]
+            account_id: actor(request).account_id
           )
         end
       end

--- a/slices/main/actions/authenticated.rb
+++ b/slices/main/actions/authenticated.rb
@@ -5,6 +5,22 @@ module Main
   module Actions
     # Action class that requires a signed in user.
     class Authenticated < Main::Action
+      # Key for authentication context in the current request.
+      #
+      # @see #actor
+      ACTOR_REQUEST_KEY = "decafsucks.main.actor"
+
+      # Authentication context for the current request.
+      #
+      # @example
+      #   actor(request).user         # current user
+      #   actor(request).account_id   # rodauth account id
+      #
+      # @see #actor
+      Actor = Data.define(:user, :account_id)
+
+      include Deps["repos.user_repo"]
+
       before :require_authentication
 
       private
@@ -14,7 +30,20 @@ module Main
 
         handle_rodauth_redirect(rodauth, response) { rodauth.require_account }
 
-        response[:current_account_id] = rodauth.account_id
+        request.env[ACTOR_REQUEST_KEY] = Actor.new(
+          account_id: rodauth.account_id,
+          user: user_repo.get_for_account(rodauth.account_id)
+        )
+      end
+
+      # Returns the {Actor} representing the current user. Use this to get the current user.
+      #
+      # @example
+      #   actor(request).user
+      #
+      # @see #require_authentication
+      def actor(request)
+        request.env[ACTOR_REQUEST_KEY]
       end
 
       # Converts a Rodauth-initiated redirect into one that works for Hanami actions.

--- a/slices/main/actions/reviews/create.rb
+++ b/slices/main/actions/reviews/create.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Main
+  module Actions
+    module Reviews
+      class Create < Authenticated
+        include Deps[create_review: "reviews.operations.create"]
+
+        def handle(request, response)
+          result = create_review.call(request.params.to_h, author_id: actor(request).user.id)
+
+          case result
+          in Success(review)
+            response.flash[:notice] = "Review created!"
+            response.redirect(routes.path(:cafe, id: review.cafe_id))
+          in Failure[:validation, validation]
+            response.render(view, errors: validation.errors.to_h)
+          in Failure[:geocoding, :not_found]
+            response.render(view, errors: {cafe_address: ["could not be located — please check the address"]})
+          in Failure
+            response.render(view, errors: {base: ["Something went wrong creating your review. Please try again."]})
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/actions/reviews/new.rb
+++ b/slices/main/actions/reviews/new.rb
@@ -5,6 +5,7 @@ module Main
     module Reviews
       class New < Authenticated
         def handle(request, response)
+          response.render(view)
         end
       end
     end

--- a/slices/main/cafes/dmetaphone.rb
+++ b/slices/main/cafes/dmetaphone.rb
@@ -1,0 +1,18 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "text"
+
+module Main
+  module Cafes
+    # Phonetic key for matching cafe names across spelling variations. The find and insert
+    # paths must agree on the calculation.
+    module Dmetaphone
+      module_function
+
+      def of(name)
+        Text::Metaphone.double_metaphone(name).first
+      end
+    end
+  end
+end

--- a/slices/main/cafes/operations/resolve.rb
+++ b/slices/main/cafes/operations/resolve.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Main
+  module Cafes
+    module Operations
+      # Returns the cafe corresponding to a given name and address, geocoding the address and
+      # creating the cafe if no nearby phonetic match exists.
+      class Resolve < Main::Operation
+        include Deps[
+          "repos.cafe_repo",
+          geocoder: "geocoding.search"
+        ]
+
+        def call(name:, address:)
+          location = step geocode(address)
+
+          cafe_repo.find_or_create_near(
+            name:,
+            address: location.display_name,
+            lat: location.lat,
+            lng: location.lng
+          )
+        end
+
+        private
+
+        def geocode(address)
+          results = geocoder.search(address)
+
+          if results.any?
+            Success(results.first)
+          else
+            Failure[:geocoding, :not_found]
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/config/slice.rb
+++ b/slices/main/config/slice.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Main
+  class Slice < Hanami::Slice
+    import keys: ["search"], from: :geocoding
+  end
+end

--- a/slices/main/operation.rb
+++ b/slices/main/operation.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Main
+  class Operation < Decafsucks::Operation
+  end
+end

--- a/slices/main/repos/cafe_repo.rb
+++ b/slices/main/repos/cafe_repo.rb
@@ -3,12 +3,46 @@
 module Main
   module Repos
     class CafeRepo < Main::DB::Repo
+      # ~0.005 decimal degrees is roughly 500m at most latitudes
+      NEARBY_THRESHOLD = 0.005
+
       def get(id)
         cafes.by_pk(id).one!
       end
 
       def latest
         cafes.order { created_at.desc }.to_a
+      end
+
+      def find_by_dmetaphone_near(name:, lat:, lng:)
+        cafes
+          .where(name_dmetaphone: Main::Cafes::Dmetaphone.of(name))
+          .where(Sequel.lit(
+            "ABS(lat - ?) < ? AND ABS(lng - ?) < ?",
+            lat, NEARBY_THRESHOLD,
+            lng, NEARBY_THRESHOLD
+          ))
+          .first
+      end
+
+      # Atomically returns the existing nearby phonetic match or inserts a new cafe.
+      #
+      # There's a possible race between the lookup and insert. The unique index on (name_dmetaphone,
+      # round(lat, 4), round(lng, 4)) means only one insert wins, and we re-read on conflict.
+      def find_or_create_near(name:, address:, lat:, lng:)
+        transaction do
+          existing = find_by_dmetaphone_near(name:, lat:, lng:)
+          return existing if existing
+
+          create(name:, address:, lat:, lng:)
+        end
+      rescue Sequel::UniqueConstraintViolation
+        find_by_dmetaphone_near(name:, lat:, lng:)
+      end
+
+      def create(attrs)
+        id = cafes.changeset(CreateChangeset, attrs).commit.fetch(:id)
+        cafes.by_pk(id).one!
       end
     end
   end

--- a/slices/main/repos/cafe_repo/create_changeset.rb
+++ b/slices/main/repos/cafe_repo/create_changeset.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Main
+  module Repos
+    class CafeRepo < Main::DB::Repo
+      class CreateChangeset < ROM::Changeset::Create
+        map do |tuple|
+          tuple.merge(name_dmetaphone: Main::Cafes::Dmetaphone.of(tuple[:name]))
+        end
+      end
+    end
+  end
+end

--- a/slices/main/repos/review_repo.rb
+++ b/slices/main/repos/review_repo.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Main
+  module Repos
+    class ReviewRepo < Main::DB::Repo
+      def create(attrs)
+        id = reviews.changeset(:create, attrs).commit.fetch(:id)
+        reviews.by_pk(id).one!
+      end
+    end
+  end
+end

--- a/slices/main/reviews/contract.rb
+++ b/slices/main/reviews/contract.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "dry/validation"
+
+module Main
+  module Reviews
+    class Contract < Dry::Validation::Contract
+      params do
+        required(:cafe_name).filled(:string)
+        required(:cafe_address).filled(:string)
+        required(:rating).filled(:integer, gteq?: 1, lteq?: 10)
+        required(:body).filled(:string)
+      end
+    end
+  end
+end

--- a/slices/main/reviews/operations/create.rb
+++ b/slices/main/reviews/operations/create.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Main
+  module Reviews
+    module Operations
+      class Create < Main::Operation
+        include Deps[
+          "reviews.contract",
+          "repos.review_repo",
+          resolve_cafe: "cafes.operations.resolve"
+        ]
+
+        def call(input, author_id:)
+          attrs = step validate(input)
+          cafe = step resolve_cafe.call(name: attrs[:cafe_name], address: attrs[:cafe_address])
+
+          review_repo.create(
+            author_id:,
+            cafe_id: cafe.id,
+            rating: attrs[:rating],
+            body: attrs[:body]
+          )
+        end
+
+        private
+
+        def validate(input)
+          validation = contract.call(input)
+
+          if validation.success?
+            Success(validation.to_h)
+          else
+            Failure[:validation, validation]
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/templates/reviews/new.html.erb
+++ b/slices/main/templates/reviews/new.html.erb
@@ -1,1 +1,45 @@
-<h1>Main::Views::Reviews::New</h1>
+<h1>Write a Review</h1>
+
+<% if (base = Array(errors[:base])).any? %>
+  <ul>
+    <% base.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for(routes.path(:reviews)) do |f| %>
+  <div>
+    <%= f.label "cafe_name" %>
+    <%= f.text_field "cafe_name" %>
+    <% Array(errors[:cafe_name]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label "cafe_address" %>
+    <%= f.text_field "cafe_address" %>
+    <% Array(errors[:cafe_address]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label "Rating (1-10)", for: "rating" %>
+    <%= f.number_field "rating", min: 1, max: 10 %>
+    <% Array(errors[:rating]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label "Review", for: "body" %>
+    <%= f.text_area "body", rows: 6 %>
+    <% Array(errors[:body]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <%= f.submit "Submit review" %>
+<% end %>

--- a/slices/main/views/reviews/new.rb
+++ b/slices/main/views/reviews/new.rb
@@ -4,6 +4,7 @@ module Main
   module Views
     module Reviews
       class New < Main::View
+        expose :errors, default: {}
       end
     end
   end

--- a/spec/slices/geocoding/services/location_iq_spec.rb
+++ b/spec/slices/geocoding/services/location_iq_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Geocoding::Services::LocationIQ do
     expect(results.length).to eq 8
     expect(results.first).to have_attributes(
       display_name: "Sigulda, Siguldas novads, LV-2150, Latvia",
-      lat: "57.1540561",
-      lng: "24.8567141"
+      lat: BigDecimal("57.1540561"),
+      lng: BigDecimal("24.8567141")
     )
   end
 end

--- a/spec/slices/main/cafes/operations/resolve_spec.rb
+++ b/spec/slices/main/cafes/operations/resolve_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Main::Cafes::Operations::Resolve, :db, :container_stubs do
+  subject(:resolve) { Main::Slice["cafes.operations.resolve"] }
+
+  let(:cafe_repo) { Main::Slice["repos.cafe_repo"] }
+
+  before { Main::Slice.container.stub("geocoding.search", fake_search) }
+
+  context "when geocoding finds the address" do
+    let(:fake_search) { instance_double(Geocoding::Search, search: [geocoding_result]) }
+    let(:geocoding_result) do
+      Geocoding::Result.new(
+        display_name: "123 Smith St, Melbourne VIC 3000, Australia",
+        lat: "-37.8136",
+        lng: "144.9631"
+      )
+    end
+
+    it "returns the existing cafe when a phonetic match exists nearby" do
+      existing = factory[:cafe, name: "Seven Seeds", lat: -37.8136, lng: 144.9631]
+
+      result = resolve.call(name: "Seven Seeds", address: "123 Smith St, Melbourne")
+
+      expect(result).to be_success
+      expect(result.value!.id).to eq existing.id
+      expect(cafe_repo.latest.size).to eq 1
+    end
+
+    it "creates a cafe with the geocoder's display_name as the address" do
+      result = resolve.call(name: "Seven Seeds", address: "anything the user typed")
+
+      expect(result).to be_success
+      expect(result.value!).to have_attributes(
+        name: "Seven Seeds",
+        address: "123 Smith St, Melbourne VIC 3000, Australia",
+        lat: -37.8136,
+        lng: 144.9631
+      )
+    end
+  end
+
+  context "when geocoding finds no results" do
+    let(:fake_search) { instance_double(Geocoding::Search, search: []) }
+
+    it "returns a geocoding not_found failure and does not create a cafe" do
+      result = resolve.call(name: "Nowhere", address: "atlantis")
+
+      expect(result).to be_failure
+      expect(result.failure).to eq [:geocoding, :not_found]
+      expect(cafe_repo.latest).to be_empty
+    end
+  end
+end

--- a/spec/slices/main/factories/cafe.rb
+++ b/spec/slices/main/factories/cafe.rb
@@ -2,7 +2,7 @@
 
 Test::Factories::Main.define(:cafe) do |f|
   f.name { "#{fake(:coffee, :blend_name)} Cafe" }
-  f.name_dmetaphone { |name| "cafe" } # TODO: add real double metaphone support
+  f.name_dmetaphone { |name| Main::Cafes::Dmetaphone.of(name) }
   f.address { fake(:address, :full_address) }
   f.lat { fake(:address, :latitude) }
   f.lng { fake(:address, :longitude) }

--- a/spec/slices/main/features/reviews/creating_a_review_spec.rb
+++ b/spec/slices/main/features/reviews/creating_a_review_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe "Reviews / Creating a review", :web, :db, :container_stubs do
+  let(:geocoding_result) do
+    Geocoding::Result.new(display_name: "123 Smith St, Melbourne VIC 3000, Australia", lat: "-37.8136", lng: "144.9631")
+  end
+
+  let(:fake_search) { instance_double(Geocoding::Search, search: [geocoding_result]) }
+
+  before do
+    Main::Slice.container.stub("geocoding.search", fake_search)
+
+    factory[
+      :account,
+      :verified,
+      email: "jane@example.com",
+      password_hash: BCrypt::Password.create("password123")
+    ]
+
+    visit "/sign-in"
+    fill_in "Email", with: "jane@example.com"
+    fill_in "Password", with: "password123"
+    within("main") { click_on "Sign in" }
+  end
+
+  it "creates a review for a new cafe" do
+    visit "/reviews/new"
+
+    fill_in "Cafe name", with: "Seven Seeds"
+    fill_in "Cafe address", with: "123 Smith St, Melbourne"
+    fill_in "Rating", with: "8"
+    fill_in "Review", with: "Excellent single origin pour over."
+
+    click_on "Submit review"
+
+    expect(page).to have_flash_message "Review created!", type: :notice
+    expect(page).to have_content("Seven Seeds")
+  end
+
+  it "attaches a review to an existing matching cafe" do
+    factory[:cafe, name: "Seven Seeds", lat: -37.8136, lng: 144.9631]
+
+    visit "/reviews/new"
+
+    fill_in "Cafe name", with: "Seven Seeds"
+    fill_in "Cafe address", with: "123 Smith St, Melbourne"
+    fill_in "Rating", with: "7"
+    fill_in "Review", with: "Great coffee."
+
+    click_on "Submit review"
+
+    expect(page).to have_flash_message "Review created!", type: :notice
+    expect(page).to have_content("Seven Seeds")
+  end
+
+  it "re-renders the form with errors for invalid input" do
+    visit "/reviews/new"
+
+    fill_in "Cafe name", with: "Seven Seeds"
+    fill_in "Cafe address", with: "123 Smith St"
+    # Leave rating and review body blank
+    click_on "Submit review"
+
+    expect(page).to have_field("Cafe name", with: "Seven Seeds")
+    within page.find_field("Cafe name").ancestor("div") do
+      expect(page).to have_no_content("must be filled")
+    end
+
+    expect(page).to have_field("Cafe address", with: "123 Smith St")
+    within page.find_field("Cafe address").ancestor("div") do
+      expect(page).to have_no_content("must be filled")
+    end
+
+    within page.find_field("Rating (1-10)").ancestor("div") do
+      expect(page).to have_content("must be filled")
+    end
+
+    within page.find_field("Review").ancestor("div") do
+      expect(page).to have_content("must be filled")
+    end
+  end
+end

--- a/spec/slices/main/repos/cafe_repo_spec.rb
+++ b/spec/slices/main/repos/cafe_repo_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Main::Repos::CafeRepo, :db do
+  subject(:cafe_repo) { Main::Slice["repos.cafe_repo"] }
+
+  describe "#find_by_dmetaphone_near" do
+    let(:lat) { -37.8136 }
+    let(:lng) { 144.9631 }
+
+    it "matches a cafe with the same phonetic name within the proximity bound" do
+      factory[:cafe, name: "Seven Seeds", lat:, lng:]
+
+      found = cafe_repo.find_by_dmetaphone_near(name: "Seven Seed", lat: lat + 0.004, lng:)
+
+      expect(found).to have_attributes(name: "Seven Seeds")
+    end
+
+    it "matches a case variation of the name" do
+      factory[:cafe, name: "Seven Seeds", lat:, lng:]
+
+      found = cafe_repo.find_by_dmetaphone_near(name: "SEVEN SEEDS", lat:, lng:)
+
+      expect(found).to have_attributes(name: "Seven Seeds")
+    end
+
+    it "does not match a cafe outside the proximity threshold" do
+      factory[:cafe, name: "Seven Seeds", lat:, lng:]
+
+      found = cafe_repo.find_by_dmetaphone_near(name: "Seven Seeds", lat: lat + 0.01, lng:)
+
+      expect(found).to be_nil
+    end
+
+    it "does not match a cafe with a different phonetic name even when nearby" do
+      factory[:cafe, name: "Seven Seeds", lat:, lng:]
+
+      found = cafe_repo.find_by_dmetaphone_near(name: "Single Origin", lat:, lng:)
+
+      expect(found).to be_nil
+    end
+  end
+end

--- a/spec/slices/main/reviews/operations/create_spec.rb
+++ b/spec/slices/main/reviews/operations/create_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe Main::Reviews::Operations::Create, :db, :container_stubs do
+  subject(:create_review) { described_class.new }
+
+  let(:author) { factory[:user] }
+
+  let(:geocoder) { instance_double(Geocoding::Search) }
+  let(:geocoding_result) {
+    Geocoding::Result.new(
+      display_name: "123 Smith St, Melbourne VIC 3000, Australia",
+      lat: "-37.8136",
+      lng: "144.9631"
+    )
+  }
+
+  let(:cafes) { Main::Slice["relations.cafes"] }
+
+  before do
+    Main::Slice.container.stub("geocoding.search", geocoder)
+  end
+
+  it "creates a cafe and a review when no nearby cafe match exists" do
+    expect(geocoder).to receive(:search).with("123 Smith St, Melbourne").and_return([geocoding_result])
+
+    result = create_review.call(
+      {
+        cafe_name: "Seven Seeds",
+        cafe_address: "123 Smith St, Melbourne",
+        rating: 8,
+        body: "Excellent single origin pour over."
+      },
+      author_id: author.id
+    )
+
+    expect(result).to be_success { |review|
+      expect(review).to have_attributes(
+        author_id: author.id,
+        rating: 8,
+        body: "Excellent single origin pour over."
+      )
+      expect(cafes.by_pk(review.cafe_id).one!).to include(
+        name: "Seven Seeds",
+        address: "123 Smith St, Melbourne VIC 3000, Australia"
+      )
+    }
+  end
+
+  it "creates a review attached to an existing nearby cafe" do
+    existing = factory[:cafe, name: "Seven Seeds", lat: -37.8136, lng: 144.9631]
+    expect(geocoder).to receive(:search).with("123 Smith St, Melbourne").and_return([geocoding_result])
+
+    result = create_review.call(
+      {
+        cafe_name: "Seven Seeds",
+        cafe_address: "123 Smith St, Melbourne",
+        rating: 8,
+        body: "Excellent single origin pour over."
+      },
+      author_id: author.id
+    )
+
+    expect(result).to be_success { |review|
+      expect(review).to have_attributes(
+        cafe_id: existing.id,
+        author_id: author.id,
+        rating: 8,
+        body: "Excellent single origin pour over."
+      )
+    }
+    expect(cafes.count).to eq 1
+  end
+
+  it "returns a validation failure for incomplete input" do
+    result = create_review.call({}, author_id: author.id)
+
+    expect(result).to be_failure { |code, validation|
+      expect(code).to eq :validation
+      expect(validation).to be_a(Dry::Validation::Result)
+    }
+  end
+
+  it "returns a geocoding not_found failure when the address cannot be located" do
+    expect(geocoder).to receive(:search).with("123 Smith St, Melbourne").and_return([])
+
+    result = create_review.call(
+      {
+        cafe_name: "Seven Seeds",
+        cafe_address: "123 Smith St, Melbourne",
+        rating: 8,
+        body: "Excellent single origin pour over."
+      },
+      author_id: author.id
+    )
+
+    expect(result).to be_failure([:geocoding, :not_found])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,5 @@ require "hanami/prepare"
 
 require_relative "support/rspec"
 require_relative "support/feature_loader"
+
+require_relative "support/monads"

--- a/spec/support/container_stubs.rb
+++ b/spec/support/container_stubs.rb
@@ -1,0 +1,18 @@
+# require_with_metadata: true
+# frozen_string_literal: true
+
+require "dry/system/stubs"
+
+RSpec.configure do |config|
+  config.when_first_matching_example_defined(:container_stubs) do
+    ([Hanami.app] + Hanami.app.slices.with_nested).each do |slice|
+      slice.container.enable_stubs!
+    end
+  end
+
+  config.after(:each, :container_stubs) do
+    ([Hanami.app] + Hanami.app.slices.with_nested).each do |slice|
+      slice.container.unstub
+    end
+  end
+end

--- a/spec/support/db/cleaning.rb
+++ b/spec/support/db/cleaning.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.before :each, :db do |example|
+  config.prepend_before :each, :db do |example|
     strategy = example.metadata[:js] ? :truncation : :transaction
 
     all_databases.call.each do |db|

--- a/spec/support/monads.rb
+++ b/spec/support/monads.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "dry/monads/extensions/rspec"


### PR DESCRIPTION
Add a `/reviews/new` screen (along with a `Cafes::Operations::Create` operation) for a signed in user to submit a cafe name, address, rating and body.

When submitted, the address is geocoded. If a nearby cafe with a matching phonetic name exists, attach the review to it. Otherwise, create a new cafe record using the geocoding result as its address.

Put this cafe resolution logic into its own operation (`Cafes::Operations::Resolve`), allowing us to separate the “identify the cafe” responsibility from the more basic “create the review” responsibility.

To support this resolve operation, add `CafeRepo#find_or_create_near`. This method is atomic, wrapping the lookup and insert in a transaction, and using a unique index on (name_dmetaphone, round(lat, 4), round(lng, 4)) to catch potential race conditions between concurrent calls.

Move the actual dmetaphone text calculation for phonetic matches into a single code location so we can depend on and use a shared implementation when both finding and creating cafes.

Since we’re referring to the current user as the author of reviews, make finding this user clearer. In authenticated actions, put a typed “Actor” (a user + account_id) under a dedicated key in request.env, so subclasses can access it through a proper accessor rather than via a symbol key lookup.

Other changes made in support of this new flow:

**Testing infra**

- Switch `DatabaseCleaner` hook from `before` to `prepend_before` for `:db` examples, so it runs before other hooks that might touch the DB. This fixes issues where I saw factory calls in a spec's own `before` block running _before_ the test transaction starts, leaving records committed outside it that leak across tests. (I previously worked around with per-test randomised emails.)
- Add a `:container_stubs` spec tag for opt-in container stubbing.
- Load the Dry Monads RSpec extension, for nicer result matching in specs.

**App/slice scaffolding**

- Add the dry-operation and dry-validation gems.
- Set up base app and slice operations (`Decafsucks::Operation` and `Main::Operation`).
- Include `Dry::Monads[:result]` in `Decafsucks::Action`, so actions can pattern match operation results.

**Other tidy-ups**

- Coerce `Geocoding::Result` lat/lng into actual `BigDecimal` values, so consumers don't have to call `.to_d`.