### PR TITLE
Add flow for reviewing an existing cafe

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ module Decafsucks
 
       root to: "home.show"
 
-      resources :cafes, only: %i[show]
+      resources :cafes, only: %i[show] do
+        resources :reviews, only: %i[new create]
+      end
       resources :reviews, only: %i[new create]
       resource :account, only: %i[show]
     end

--- a/slices/main/actions/cafes/reviews/create.rb
+++ b/slices/main/actions/cafes/reviews/create.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Main
+  module Actions
+    module Cafes
+      module Reviews
+        class Create < Authenticated
+          include Deps[create_review: "reviews.operations.create_for_cafe"]
+
+          def handle(request, response)
+            request.params => {cafe_id:}
+            result = create_review.call(
+              request.params.to_h,
+              author_id: actor(request).user.id,
+              cafe_id:
+            )
+
+            case result
+            in Success(review)
+              response.flash[:notice] = "Review created!"
+              response.redirect(routes.path(:cafe, id: review.cafe_id))
+            in Failure[:validation, validation]
+              response.render(view, cafe_id:, errors: validation.errors.to_h)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/actions/cafes/reviews/new.rb
+++ b/slices/main/actions/cafes/reviews/new.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Main
+  module Actions
+    module Cafes
+      module Reviews
+        class New < Authenticated
+          def handle(request, response)
+            request.params => {cafe_id:}
+            response.render(view, cafe_id:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/reviews/contract.rb
+++ b/slices/main/reviews/contract.rb
@@ -6,8 +6,8 @@ module Main
   module Reviews
     class Contract < Dry::Validation::Contract
       params do
-        required(:cafe_name).filled(:string)
-        required(:cafe_address).filled(:string)
+        optional(:cafe_name).filled(:string)
+        optional(:cafe_address).filled(:string)
         required(:rating).filled(:integer, gteq?: 1, lteq?: 10)
         required(:body).filled(:string)
       end

--- a/slices/main/reviews/operations/create_for_cafe.rb
+++ b/slices/main/reviews/operations/create_for_cafe.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Main
+  module Reviews
+    module Operations
+      class CreateForCafe < Main::Operation
+        include Deps[
+          "reviews.contract",
+          "repos.review_repo"
+        ]
+
+        def call(input, author_id:, cafe_id:)
+          attrs = step validate(input)
+
+          review_repo.create(
+            author_id:,
+            cafe_id:,
+            rating: attrs[:rating],
+            body: attrs[:body]
+          )
+        end
+
+        private
+
+        def validate(input)
+          validation = contract.call(input)
+
+          if validation.success?
+            Success(validation.to_h)
+          else
+            Failure[:validation, validation]
+          end
+        end
+      end
+    end
+  end
+end

--- a/slices/main/templates/cafes/reviews/new.html.erb
+++ b/slices/main/templates/cafes/reviews/new.html.erb
@@ -1,0 +1,29 @@
+<h1>Write a Review for <%= cafe.name %></h1>
+
+<% if (base = Array(errors[:base])).any? %>
+  <ul>
+    <% base.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for(routes.path(:cafe_reviews, cafe_id: cafe.id)) do |f| %>
+  <div>
+    <%= f.label "Rating (1-10)", for: "rating" %>
+    <%= f.number_field "rating", min: 1, max: 10 %>
+    <% Array(errors[:rating]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <div>
+    <%= f.label "Review", for: "body" %>
+    <%= f.text_area "body", rows: 6 %>
+    <% Array(errors[:body]).each do |msg| %>
+      <span><%= msg %></span>
+    <% end %>
+  </div>
+
+  <%= f.submit "Submit review" %>
+<% end %>

--- a/slices/main/templates/cafes/show.html.erb
+++ b/slices/main/templates/cafes/show.html.erb
@@ -6,4 +6,8 @@
     data-defo-cafe-map='{"lat": <%= cafe.lat %>, "lng": <%= cafe.lng %>, "name": "<%= cafe.name %>"}'
     class="h-96 w-full rounded-lg shadow-lg mb-6">
   </div>
+
+  <p>
+    <a href="<%= routes.path(:new_cafe_review, cafe_id: cafe.id) %>">Write a review</a>
+  </p>
 </div>

--- a/slices/main/views/cafes/reviews/new.rb
+++ b/slices/main/views/cafes/reviews/new.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Main
+  module Views
+    module Cafes
+      module Reviews
+        class New < Main::View
+          include Deps["repos.cafe_repo"]
+
+          expose :cafe do |cafe_id:|
+            cafe_repo.get(cafe_id)
+          end
+
+          expose :errors, default: {}
+        end
+      end
+    end
+  end
+end

--- a/spec/slices/main/features/reviews/reviewing_a_cafe_spec.rb
+++ b/spec/slices/main/features/reviews/reviewing_a_cafe_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe "Reviews / Reviewing a cafe", :web, :db do
+  before do
+    factory[
+      :account,
+      :verified,
+      email: "jane@example.com",
+      password_hash: BCrypt::Password.create("password123")
+    ]
+
+    visit "/sign-in"
+    fill_in "Email", with: "jane@example.com"
+    fill_in "Password", with: "password123"
+    within("main") { click_on "Sign in" }
+  end
+
+  it "creates a review for the cafe" do
+    cafe = factory[:cafe, name: "Seven Seeds"]
+
+    visit "/cafes/#{cafe.id}"
+    click_on "Write a review"
+
+    expect(page).to have_content("Write a Review for Seven Seeds")
+
+    fill_in "Rating", with: "8"
+    fill_in "Review", with: "Excellent single origin pour over."
+
+    click_on "Submit review"
+
+    expect(page).to have_flash_message "Review created!", type: :notice
+    expect(page).to have_content("Seven Seeds")
+  end
+
+  it "re-renders the form with errors for invalid input" do
+    cafe = factory[:cafe, name: "Seven Seeds"]
+
+    visit "/cafes/#{cafe.id}/reviews/new"
+
+    # Leave rating and review body blank
+    click_on "Submit review"
+
+    expect(page).to have_content("Write a Review for Seven Seeds")
+
+    within page.find_field("Rating (1-10)").ancestor("div") do
+      expect(page).to have_content("must be filled")
+    end
+
+    within page.find_field("Review").ancestor("div") do
+      expect(page).to have_content("must be filled")
+    end
+  end
+end

--- a/spec/slices/main/reviews/operations/create_for_cafe_spec.rb
+++ b/spec/slices/main/reviews/operations/create_for_cafe_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Main::Reviews::Operations::CreateForCafe, :db do
+  subject(:create_review) { described_class.new }
+
+  let(:author) { factory[:user] }
+  let(:cafe) { factory[:cafe, name: "Seven Seeds"] }
+
+  let(:reviews) { Main::Slice["relations.reviews"] }
+
+  it "creates a review for the given cafe" do
+    result = create_review.call(
+      {rating: 8, body: "Excellent single origin pour over."},
+      author_id: author.id,
+      cafe_id: cafe.id
+    )
+
+    expect(result).to be_success
+    expect(reviews.to_a).to contain_exactly(
+      a_hash_including(
+        author_id: author.id,
+        cafe_id: cafe.id,
+        rating: 8,
+        body: "Excellent single origin pour over."
+      )
+    )
+  end
+
+  it "returns a validation failure for incomplete input" do
+    result = create_review.call({}, author_id: author.id, cafe_id: cafe.id)
+
+    expect(result).to be_failure { |code, validation|
+      expect(code).to eq :validation
+      expect(validation).to be_a(Dry::Validation::Result)
+    }
+  end
+end

--- a/spec/slices/main/reviews/operations/create_spec.rb
+++ b/spec/slices/main/reviews/operations/create_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Main::Reviews::Operations::Create, :db, :container_stubs do
   }
 
   let(:cafes) { Main::Slice["relations.cafes"] }
+  let(:reviews) { Main::Slice["relations.reviews"] }
 
   before do
     Main::Slice.container.stub("geocoding.search", geocoder)
@@ -33,17 +34,20 @@ RSpec.describe Main::Reviews::Operations::Create, :db, :container_stubs do
       author_id: author.id
     )
 
-    expect(result).to be_success { |review|
-      expect(review).to have_attributes(
+    expect(result).to be_success
+    expect(cafes.to_a).to contain_exactly(
+      a_hash_including(
+        name: "Seven Seeds",
+        address: "123 Smith St, Melbourne VIC 3000, Australia"
+      )
+    )
+    expect(reviews.to_a).to contain_exactly(
+      a_hash_including(
         author_id: author.id,
         rating: 8,
         body: "Excellent single origin pour over."
       )
-      expect(cafes.by_pk(review.cafe_id).one!).to include(
-        name: "Seven Seeds",
-        address: "123 Smith St, Melbourne VIC 3000, Australia"
-      )
-    }
+    )
   end
 
   it "creates a review attached to an existing nearby cafe" do
@@ -60,14 +64,15 @@ RSpec.describe Main::Reviews::Operations::Create, :db, :container_stubs do
       author_id: author.id
     )
 
-    expect(result).to be_success { |review|
-      expect(review).to have_attributes(
-        cafe_id: existing.id,
+    expect(result).to be_success
+    expect(reviews.to_a).to contain_exactly(
+      a_hash_including(
         author_id: author.id,
+        cafe_id: existing.id,
         rating: 8,
         body: "Excellent single origin pour over."
       )
-    }
+    )
     expect(cafes.count).to eq 1
   end
 


### PR DESCRIPTION
Add a `/cafes/:cafe_id/reviews/new` screen, linked from the cafe show page, for a signed in user to submit a new review for an existing cafe.

Implement this as a nested `resources :reviews` inside `resources :cafes`, so the route reflects the cafe scoping.

Add `Reviews::Operations::CreateForCafe` for this flow. Since the cafe is already known, it skips the geocoding/resolve dance the existing `Reviews::Operations::Create` performs and just creates the review against the given `cafe_id`.

Share `Reviews::Contract` between both operations rather than introducing a second contract. Make the cafe lookup fields (`cafe_name`, `cafe_address`) optional keys to support this.

As part of testing this, move towards an approach in the operation specs that verifies the actual persistence of the review to the database.