### PR TITLE
Update to Postgres 18; let binstubs read CLI file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,12 @@ jobs:
         run: bundle exec rubocop
   tests:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:18-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
+    env:
+      # Replicate what mise provides locally for the Postgres binstubs
+      DECAFSUCKS_POSTGRES_CLI_USER: postgres
+      DECAFSUCKS_POSTGRES_CLI_PASSWORD: postgres
+      DECAFSUCKS_POSTGRES_PORT: 5432
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/decafsucks_test
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -37,12 +35,16 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Put binstubs on PATH
+        run: echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Start Postgres
+        run: |
+          docker compose up -d postgres
+          until docker compose exec -T postgres pg_isready -U postgres; do sleep 1; done
       - name: Run tests
-        env:
-          DATABASE_URL: postgres://postgres:password@localhost:5432/decafsucks_test
         run: |
           HANAMI_ENV=test bundle exec hanami db create
-          PGPASSWORD=password psql -h localhost -U postgres -d decafsucks_test -c "CREATE EXTENSION IF NOT EXISTS citext;"
+          bin/psql -d decafsucks_test -c "CREATE EXTENSION IF NOT EXISTS citext;"
           HANAMI_ENV=test bundle exec hanami db migrate --no-dump
           bundle exec rake tailwind:compile
           bundle exec hanami assets compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/bin/createdb
+++ b/bin/createdb
@@ -1,13 +1,13 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Delegates to createdb inside the postgres Docker container.
 #
 # Expects the "postgres" service from docker-compose.yml to be running.
 
-# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with -T
 # otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
-TTY_FLAG="--no-tty"
+TTY_FLAG="-T"
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAG=""
 fi

--- a/bin/dropdb
+++ b/bin/dropdb
@@ -1,13 +1,13 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Delegates to dropdb inside the postgres Docker container.
 #
 # Expects the "postgres" service from docker-compose.yml to be running.
 
-# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with -T
 # otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
-TTY_FLAG="--no-tty"
+TTY_FLAG="-T"
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAG=""
 fi

--- a/bin/pg_dump
+++ b/bin/pg_dump
@@ -1,13 +1,13 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Delegates to pg_dump inside the postgres Docker container.
 #
 # Expects the "postgres" service from docker-compose.yml to be running.
 
-# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with -T
 # otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
-TTY_FLAG="--no-tty"
+TTY_FLAG="-T"
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAG=""
 fi

--- a/bin/pg_restore
+++ b/bin/pg_restore
@@ -1,13 +1,13 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Delegates to pg_restore inside the postgres Docker container.
 #
 # Expects the "postgres" service from docker-compose.yml to be running.
 
-# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with -T
 # otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
-TTY_FLAG="--no-tty"
+TTY_FLAG="-T"
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAG=""
 fi

--- a/bin/psql
+++ b/bin/psql
@@ -1,13 +1,13 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 # Delegates to psql inside the postgres Docker container.
 #
 # Expects the "postgres" service from docker-compose.yml to be running.
 
-# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with --no-tty
+# Allocate a TTY for interactive use (e.g. a human running psql), but disable it with -T
 # otherwise, so piped data (e.g. from the `hanami db` commands) isn't corrupted by terminal codes.
-TTY_FLAG="--no-tty"
+TTY_FLAG="-T"
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAG=""
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,17 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
       - "${DECAFSUCKS_POSTGRES_PORT:-55432}:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
+      # Mount the project at its own host path so our container-aware Postgres binstubs can read
+      # absolute paths provided by the hanami CLI (e.g. `psql --file .../config/db/structure.sql`
+      # used by `db structure load`).
+      - ${PWD}:${PWD}:ro
   mailpit:
     image: axllent/mailpit
     container_name: mailpit


### PR DESCRIPTION
Bump the postgres image to 18-alpine and move the data volume mount up to `/var/lib/postgresql`, which is what the Postgres 18+ images expect.

Also, bind-mount the project into the container at its own host path (`${PWD}:${PWD}`) so our container-aware Postgres binstubs can read files that are given to them as absolute paths. This is required for `hanami db structure load` to run successfully.

Finally, switch CI to run Postgres through these same binstubs, rather than the runner's host psql client. The runner's client is still on v16 and was holding us back. Now, we start Postgres on CI via our own compose file, and put our binstubs on the PATH so they can be invoked.

This CI change also revealed some portability bugs in our binstubs: (a) `set -o pipefail` didn't work on plain sh (and wasn't needed anyway), and (b) the `--no-tty` argument we pass to docker isn't supported in the version on CI, so we switch to `-T` instead.