### PR TITLE
Update bin/setup with npm install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,6 +12,9 @@ def setup
   system! "gem install bundler --conservative"
   system! "bundle check || bundle install"
 
+  header "Installing node packages"
+  system! "npm install"
+
   header "💾 Preparing databases"
   system! "bundle exec hanami db prepare"
   system! "bundle exec hanami db seed -e test" # FIXME: this should be run by `db prepare`


### PR DESCRIPTION
I was setting this project locally by following the instructions in README, but I found the following issue when running `bin/dev`:

```
12:17:06 assets.1   | [main] node:internal/modules/package_json_reader:256
12:17:06 assets.1   | [decafsucks] node:internal/modules/package_json_reader:256
12:17:06 assets.1   | [main]   throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
12:17:06 assets.1   | [decafsucks]   throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
12:17:06 assets.1   | [main]         ^
12:17:06 assets.1   | [decafsucks]         ^
12:17:06 assets.1   | [main]
12:17:06 assets.1   | [main] Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'hanami-assets' imported from /Users/javier/Developer/decafsucks/config/assets.js
```

It was fixed by running `npm install`, so I'm suggesting this change to the setup script, but happy to adjust the approach if something else makes more sense.